### PR TITLE
Add null provider to support the privacy API

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,13 @@
+<?php
+namespace block_equella_links\privacy;
+
+class provider implements \core_privacy\local\metadata\null_provider {
+    //this plugin does not store any personal user data.
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -2,7 +2,7 @@
 namespace block_equella_links\privacy;
 
 class provider implements \core_privacy\local\metadata\null_provider {
-    //this plugin does not store any personal user data.
+    // this plugin does not store any personal user data.
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.

--- a/lang/en/block_equella_links.php
+++ b/lang/en/block_equella_links.php
@@ -36,4 +36,4 @@ $string['deletelinkconfirm'] = 'Are you sure you want to delete this openEQUELLA
 
 $string['configincludetaggeditems'] = 'Content tagged to this course (inc. eReadings)';
 $string['configxmlpath'] = 'XML Path (your EQ admin can provide)';
-$string['privacy:metadata'] = "The LINKS block does not store any data - it uses shared secret to interact with openEQUELLA.";
+$string['privacy:metadata'] = "This block does not store any data - it uses a shared secret to interact with openEQUELLA";

--- a/lang/en/block_equella_links.php
+++ b/lang/en/block_equella_links.php
@@ -36,3 +36,4 @@ $string['deletelinkconfirm'] = 'Are you sure you want to delete this openEQUELLA
 
 $string['configincludetaggeditems'] = 'Content tagged to this course (inc. eReadings)';
 $string['configxmlpath'] = 'XML Path (your EQ admin can provide)';
+$string['privacy:metadata'] = "The LINKS block does not store any data - it uses shared secret to interact with openEQUELLA.";

--- a/lang/en/block_equella_links.php
+++ b/lang/en/block_equella_links.php
@@ -36,4 +36,4 @@ $string['deletelinkconfirm'] = 'Are you sure you want to delete this openEQUELLA
 
 $string['configincludetaggeditems'] = 'Content tagged to this course (inc. eReadings)';
 $string['configxmlpath'] = 'XML Path (your EQ admin can provide)';
-$string['privacy:metadata'] = "This block does not store any data - it uses a shared secret to interact with openEQUELLA";
+$string['privacy:metadata'] = "This block does not store any data.";

--- a/version.php
+++ b/version.php
@@ -24,6 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2015061200;
+$plugin->version = 2020032500;
 $plugin->component = 'block_equella_links'; // Full name of the plugin (used for diagnostics)
 $plugin->cron      = 86400;                 // Set min time between cron executions to 24 hours
+$plugin->release = "1.0.0";


### PR DESCRIPTION
Moodle now adheres to the GDPR which means we need to implement a privacy provider. 
See https://docs.moodle.org/dev/Privacy_API#Plugins_which_do_not_store_personal_data for details.  

![image](https://user-images.githubusercontent.com/24543345/91247543-d7823700-e795-11ea-8da0-036e3d89578a.png)
