### PR TITLE
has_config() should return false

### DIFF
--- a/block_equella_links.php
+++ b/block_equella_links.php
@@ -23,7 +23,7 @@ require_once($CFG->dirroot.'/blocks/moodleblock.class.php');
 
 class block_equella_links extends block_list {
     function has_config() {
-        return true;
+        return false;
     }
 
     public function instance_allow_config() {


### PR DESCRIPTION
because there's no settings.php file for this plugin.

After installing the plugin, I saw this warning on the "Manage Blocks" (moodle/admin/blocks.php) page:

> Warning: block_equella_links returns true in has_config() but does not provide a settings.php file
> line 147 of /admin/blocks.php: call to debugging()

I have debugging on so you may not see this warning without that. After this simple edit, the warning goes away.